### PR TITLE
Fix typo in Splitter.cpp. Also increase the range of the tmp histogram . . .

### DIFF
--- a/UserTools/Calibrate.cpp
+++ b/UserTools/Calibrate.cpp
@@ -27,7 +27,7 @@ bool Calibrate::Initialise(std::string configfile, DataModel &data){
 
 bool Calibrate::Execute(){
 
-  TH1I tmp("test","test",1000,0,999);
+  TH1I tmp("test","test",10000,0,9999);
 
   for(int i=0; i<m_data->splittree->BufferSize; i++){
     tmp.Fill(m_data->splittree->UnCalData[i]);

--- a/UserTools/Splitter.cpp
+++ b/UserTools/Splitter.cpp
@@ -37,7 +37,7 @@ bool Splitter::Initialise(std::string configfile, DataModel &data){
           
     if(*(m_data->RunInformationData->InfoTitle)=="TriggerVariables"){
       
-      triggerinfo.JsonPaser(*(m_data->RunInformationData->InfoMessage));
+      triggerinfo.JsonParser(*(m_data->RunInformationData->InfoMessage));
     
     }
   }


### PR DESCRIPTION
in Calibrate::Execute() to ensure that the uncalibrated HeftySource data do not fall into the overflow bin. When all counts in tmp fall into the overflow bin, the Gaussian fit fails, causing a segmentation fault.